### PR TITLE
only use one source attribute because git signing makes it a pain

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -25,38 +25,35 @@ jobs:
   - in_parallel:
     - get: pipeline-config
       trigger: true
-    - get: pipeline-source
+    - get: source
       trigger: true
       params: {depth: 1}
   - set_pipeline: docker-registry-mirror
-    file: pipeline-source/ci/pipeline.yml
-    var_files: 
+    file: source/ci/pipeline.yml
+    var_files:
       - pipeline-config/docker-registry-mirror.yml
 
 - name: deploy-registry-staging
   serial_groups: [mirror]
   plan:
-  - in_parallel: 
-    - get: registry-source
-      trigger: true
-      params: {depth: 1}
+  - in_parallel:
     - get: docker-registry-image
       trigger: true
-    - get: ci-source
+    - get: source
       params: {depth: 1}
   - task: create-s3-bucket
-    file: ci-source/ci/tasks/create-s3-bucket.yml
+    file: source/ci/tasks/create-s3-bucket.yml
     params:
       <<: *staging-cf
   - task: deploy-registry
-    file: ci-source/ci/tasks/deploy-registry.yml
+    file: source/ci/tasks/deploy-registry.yml
     params:
       <<: *staging-cf
     # Don't cancel the deployment in staging so we can debug the failure
     # on_failure:
     #   try:
     #     task: cancel-deployment
-    #     file: ci-source/ci/tasks/cancel-deployment.yml
+    #     file: source/ci/tasks/cancel-deployment.yml
     #     params:
     #       <<: *staging-cf
     #       CF_APP_NAME: docker-registry-mirror
@@ -68,7 +65,7 @@ jobs:
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))
-      icon_url: ((slack-icon-url))  
+      icon_url: ((slack-icon-url))
 
 - name: deploy-proxy-staging
   serial_groups: [proxy]
@@ -76,21 +73,19 @@ jobs:
   - in_parallel:
     - get: nginx-conf
       trigger: true
-    - get: proxy-source
+    - get: source
       trigger: true
       params: {depth: 1}
-    - get: ci-source
-      params: {depth: 1}
   - task: deploy-proxy
-    file: ci-source/ci/tasks/deploy-proxy.yml
+    file: source/ci/tasks/deploy-proxy.yml
     tags: [iaas]
-    params: 
+    params:
       <<: *staging-cf
     # Don't cancel the deployment in staging so we can debug the failure
     # on_failure:
-    #   try: 
+    #   try:
     #     task: cancel-deployment
-    #     file: ci-source/ci/tasks/cancel-deployment.yml
+    #     file: source/ci/tasks/cancel-deployment.yml
     #     params:
     #       <<: *staging-cf
     #       CF_APP_NAME: docker-registry-proxy
@@ -106,7 +101,7 @@ jobs:
   serial_groups: [mirror,proxy]
   plan:
   - in_parallel:
-    - get: registry-source
+    - get: source
       trigger: true
       params: {depth: 1}
       passed: [deploy-registry-staging]
@@ -116,12 +111,6 @@ jobs:
     - get: nginx-conf
       trigger: true
       passed: [deploy-proxy-staging]
-    - get: proxy-source
-      trigger: true
-      params: {depth: 1}
-      passed: [deploy-proxy-staging]
-    - get: ci-source
-      params: {depth: 1}
   # Be sure we can pull an image through the mirror using the docker-image resource type
   - task: test-pull-succeeds-docker-image
     config:
@@ -145,7 +134,7 @@ jobs:
         type: registry-image
         source:
           repository: 18fgsa/concourse-task
-          registry_mirror: 
+          registry_mirror:
             host: "((staging-mirror-hostname)).app.cloud.gov:443"
       run:
         path: /bin/sh
@@ -154,7 +143,7 @@ jobs:
         - |
           date
   - task: test-no-push
-    file: ci-source/ci/tasks/test-no-push.yml
+    file: source/ci/tasks/test-no-push.yml
     params:
       MIRROR_HOSTNAME: ((staging-mirror-hostname))
   on_failure:
@@ -175,26 +164,24 @@ jobs:
 - name: deploy-registry-production
   serial_groups: [mirror]
   plan:
-  - in_parallel: 
-    - get: registry-source
+  - in_parallel:
+    - get: source
       params: {depth: 1}
       passed: [integration-test]
     - get: docker-registry-image
       passed: [integration-test]
-    - get: ci-source
-      params: {depth: 1}
   - task: create-s3-bucket
-    file: ci-source/ci/tasks/create-s3-bucket.yml
+    file: source/ci/tasks/create-s3-bucket.yml
     params:
       <<: *production-cf
   - task: deploy-registry
-    file: ci-source/ci/tasks/deploy-registry.yml
+    file: source/ci/tasks/deploy-registry.yml
     params:
       <<: *production-cf
     on_failure:
       try:
         task: cancel-deployment
-        file: ci-source/ci/tasks/cancel-deployment.yml
+        file: source/ci/tasks/cancel-deployment.yml
         params:
           <<: *production-cf
           CF_APP_NAME: docker-registry-mirror
@@ -202,11 +189,11 @@ jobs:
     put: slack
     params: &slack-params
       text: |
-        :x: FAILED to deploy docker registry mirror to production. Deployment was canceled (rolled back). 
+        :x: FAILED to deploy docker registry mirror to production. Deployment was canceled (rolled back).
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-channel))
       username: ((slack-username))
-      icon_url: ((slack-icon-url))  
+      icon_url: ((slack-icon-url))
 
 - name: deploy-proxy-production
   serial_groups: [proxy]
@@ -214,20 +201,18 @@ jobs:
   - in_parallel:
     - get: nginx-conf
       passed: [integration-test]
-    - get: proxy-source
+    - get: source
       params: {depth: 1}
       passed: [integration-test]
-    - get: ci-source
-      params: {depth: 1}
   - task: deploy-proxy
-    file: ci-source/ci/tasks/deploy-proxy.yml
+    file: source/ci/tasks/deploy-proxy.yml
     tags: [iaas]
-    params: 
+    params:
       <<: *production-cf
     on_failure:
-      try: 
+      try:
         task: cancel-deployment
-        file: ci-source/ci/tasks/cancel-deployment.yml
+        file: source/ci/tasks/cancel-deployment.yml
         params:
           <<: *production-cf
           CF_APP_NAME: docker-registry-proxy
@@ -249,20 +234,6 @@ resources:
     region_name: ((concourse-creds-bucket-region))
     versioned_file: docker-registry-mirror.yml
 
-- name: pipeline-source
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/docker-registry-mirror.git
-    paths: [ci/pipeline.yml]
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-
-- name: ci-source
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/docker-registry-mirror.git
-    paths: [ci/*]
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-
 - name: nginx-conf
   type: s3-iam
   tags: [iaas]
@@ -271,18 +242,10 @@ resources:
     region_name: ((concourse-varz-bucket-region))
     versioned_file: docker-registry-mirror/nginx/nginx.conf
 
-- name: proxy-source
+- name: source
   type: git
   source:
     uri: https://github.com/cloud-gov/docker-registry-mirror.git
-    paths: [proxy/*]
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-
-- name: registry-source
-  type: git
-  source:
-    uri: https://github.com/cloud-gov/docker-registry-mirror.git
-    paths: [registry/*]
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
 - name: docker-registry-image


### PR DESCRIPTION


## Changes proposed in this pull request:

- only use one source attribute because git signing makes it a pain
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None