### PR TITLE
use hardened images

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -41,11 +41,14 @@ jobs:
       trigger: true
     - get: source
       params: {depth: 1}
+    - get: general-task
   - task: create-s3-bucket
+    image: general-task
     file: source/ci/tasks/create-s3-bucket.yml
     params:
       <<: *staging-cf
   - task: deploy-registry
+    image: general-task
     file: source/ci/tasks/deploy-registry.yml
     params:
       <<: *staging-cf
@@ -76,7 +79,9 @@ jobs:
     - get: source
       trigger: true
       params: {depth: 1}
+    - get: general-task
   - task: deploy-proxy
+    image: general-task
     file: source/ci/tasks/deploy-proxy.yml
     tags: [iaas]
     params:
@@ -118,7 +123,7 @@ jobs:
       image_resource:
         type: docker-image
         source:
-          repository: 18fgsa/concourse-task
+          repository: ubuntu:22.04
           registry_mirror: "https://((staging-mirror-hostname)).app.cloud.gov:443"
       run:
         path: /bin/sh
@@ -133,7 +138,7 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: 18fgsa/concourse-task
+          repository: ubuntu:22.04
           registry_mirror:
             host: "((staging-mirror-hostname)).app.cloud.gov:443"
       run:
@@ -258,14 +263,48 @@ resources:
   source:
     url: ((slack-webhook-url))
 
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
+
 resource_types:
+- name: registry-image
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
-    repository: 18fgsa/s3-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: s3-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: slack-notification
-  type: docker-image
+  type: registry-image
   source:
-    repository: cfcommunity/slack-notification-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: slack-notification-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: git
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: git-resource
+    aws_region: us-gov-west-1
+    tag: latest

--- a/ci/tasks/create-s3-bucket.yml
+++ b/ci/tasks/create-s3-bucket.yml
@@ -1,9 +1,5 @@
 ---
 platform: linux
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
 
 inputs:
 - name: source

--- a/ci/tasks/deploy-proxy.yml
+++ b/ci/tasks/deploy-proxy.yml
@@ -1,9 +1,5 @@
 ---
 platform: linux
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
 
 inputs:
 - name: nginx-conf

--- a/ci/tasks/deploy-registry.yml
+++ b/ci/tasks/deploy-registry.yml
@@ -1,9 +1,5 @@
 ---
 platform: linux
-image_resource:
-  type: docker-image
-  source:
-    repository: 18fgsa/concourse-task
 
 inputs:
 - name: source


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update the pipeline to use hardened images
- Test using the ubuntu dockerhub image, rather than the old dockerhub general-task image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

We may eventually retire this pipeline, but for now this updates the pipeline to use hardened images and removes references to the dockerhub general-task image
