### PR TITLE
fix test to reference repo and tag

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -124,7 +124,8 @@ jobs:
       image_resource:
         type: docker-image
         source:
-          repository: ubuntu:22.04
+          repository: ubuntu
+          tag: 22.04
           registry_mirror: "https://((staging-mirror-hostname)).app.cloud.gov:443"
       run:
         path: /bin/sh
@@ -139,7 +140,8 @@ jobs:
       image_resource:
         type: registry-image
         source:
-          repository: ubuntu:22.04
+          repository: ubuntu
+          tag: 22.04
           registry_mirror:
             host: "((staging-mirror-hostname)).app.cloud.gov:443"
       run:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes tests to correctly reference image repo and tag

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Fixes tests
